### PR TITLE
Change teamleader.eu urls to focus.teamleader.eu

### DIFF
--- a/src/services/TeamleaderConnection.php
+++ b/src/services/TeamleaderConnection.php
@@ -34,17 +34,17 @@ class TeamleaderConnection extends Connection
     /**
      * @var string
      */
-    private $apiUrl = 'https://api.teamleader.eu';
+    private $apiUrl = 'https://api.focus.teamleader.eu';
 
     /**
      * @var string
      */
-    private $authUrl = 'https://app.teamleader.eu/oauth2/authorize';
+    private $authUrl = 'https://focus.teamleader.eu/oauth2/authorize';
 
     /**
      * @var string
      */
-    private $tokenUrl = 'https://app.teamleader.eu/oauth2/access_token';
+    private $tokenUrl = 'https://focus.teamleader.eu/oauth2/access_token';
 
     /**
      * @var string

--- a/src/templates/connect/index.twig
+++ b/src/templates/connect/index.twig
@@ -44,7 +44,7 @@
     {% if token is not empty %}
         <p>{{ "Connection is allready established"|t('teamleader') }}</p>
     {% else %}
-        <a href="https://app.teamleader.eu/oauth2/authorize?client_id={{ settings['clientId'] }}&response_type=code&redirect_uri={{ settings['baseUrl'] }}/admin/teamleader/connect/integration" class="btn submit add icon">{{ "Connect Teamleader"|t('teamleader') }}</a>
+        <a href="https://focus.teamleader.eu/oauth2/authorize?client_id={{ settings['clientId'] }}&response_type=code&redirect_uri={{ settings['baseUrl'] }}/admin/teamleader/connect/integration" class="btn submit add icon">{{ "Connect Teamleader"|t('teamleader') }}</a>
     {% endif %}
     <p class="textline"></p>
 {% endset %}


### PR DESCRIPTION
The Teamleader application has been renamed to Teamleader Focus, more info about this can be found [here](https://www.teamleader.eu/blog/new-names-teamleader-focus-orbit). This product name change also means that the application, api, marketplace, etc. have a new home under [focus.teamleader.eu](https://focus.teamleader.eu).

This PR changes the Teamleader URLs in this repo to point to [focus.teamleader.eu](https://focus.teamleader.eu). The switch to these new URLs isn't urgent though, the old URLs will remain available for some time.